### PR TITLE
Introduce mountFlagedEngine to flag engines

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,26 +1,33 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>FeatureFlagEmberPlayground</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- {a:0,b:0,application:0} -->
-    <meta name="feature-flags" content="%7B%22a%22:0,%22b%22:0,%22education%22:%22enabled%22,%22application%22:0%7D">
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- {"flags":{"a":0,"b":0,"education":"enabled","application":0,"new.about":"enabled","new.super-blog":"enabled"},"routingFlags":{"mountPoints":{"about":{"key":"new.about","enabledEngine":"new-about"},"super-blog":{"key":"new.super-blog","enabledEngine":"new-super-blog"}}}} -->
+    <meta
+      name="feature-flags"
+      content="%7B%22flags%22:%7B%22a%22:0,%22b%22:0,%22education%22:%22enabled%22,%22application%22:0,%22new.about%22:%22enabled%22,%22new.super-blog%22:%22enabled%22%7D,%22routingFlags%22:%7B%22mountPoints%22:%7B%22about%22:%7B%22key%22:%22new.about%22,%22enabledEngine%22:%22new-about%22%7D,%22super-blog%22:%7B%22key%22:%22new.super-blog%22,%22enabledEngine%22:%22new-super-blog%22%7D%7D%7D%7D"
+    />
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/feature-flag-ember-playground.css">
+    <link integrity="" rel="stylesheet" href="{{ rootURL }}assets/vendor.css" />
+    <link
+      integrity=""
+      rel="stylesheet"
+      href="{{ rootURL }}assets/feature-flag-ember-playground.css"
+    />
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/feature-flag-ember-playground.js"></script>
+    <script src="{{ rootURL }}assets/vendor.js"></script>
+    <script src="{{ rootURL }}assets/feature-flag-ember-playground.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/app/router.js
+++ b/app/router.js
@@ -1,6 +1,18 @@
 import EmberRouter from '@embroider/router';
 import config from './config/environment';
 
+function mountFlagedEngine(/*this: DSLImpl*/engineMountPoint) {
+  const flagConfig = JSON.parse(
+    decodeURI(document.querySelector('meta[name=feature-flags]').content)
+  );
+  const engineConfig = flagConfig.routingFlags.mountPoints[engineMountPoint];
+  if (flagConfig.flags[engineConfig.key] === 'enabled') {
+    this.mount(engineConfig.enabledEngine, { as: engineMountPoint });
+  } else {
+    this.mount(engineMountPoint);
+  }
+}
+
 export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
@@ -11,6 +23,6 @@ Router.map(function () {
     this.route('connections');
     this.route('education');
   });
-  this.mount('super-blog');
-  this.mount('about');
+  mountFlagedEngine.call(this, 'super-blog');
+  mountFlagedEngine.call(this, 'about');
 });

--- a/app/services/flag.js
+++ b/app/services/flag.js
@@ -113,7 +113,7 @@ const STORE = new Map(
   Object.entries(
     JSON.parse(
       decodeURI(document.querySelector('meta[name=feature-flags]').content)
-    )
+    ).flags
   )
 );
 

--- a/lib/new-about/addon/engine.js
+++ b/lib/new-about/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from './resolver';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/lib/new-about/addon/resolver.js
+++ b/lib/new-about/addon/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/lib/new-about/addon/routes.js
+++ b/lib/new-about/addon/routes.js
@@ -1,0 +1,6 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function () {
+  // Define your engine's route map here
+  this.route('contact', { path: 'contact/:id' });
+});

--- a/lib/new-about/addon/routes/contact.js
+++ b/lib/new-about/addon/routes/contact.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class ContactRoute extends Route {
+  model({ id }) {
+    return { id };
+  }
+}

--- a/lib/new-about/addon/templates/application.hbs
+++ b/lib/new-about/addon/templates/application.hbs
@@ -1,0 +1,3 @@
+<h1>NEW About Engine (lazy)</h1>
+
+{{outlet}}

--- a/lib/new-about/addon/templates/contact.hbs
+++ b/lib/new-about/addon/templates/contact.hbs
@@ -1,0 +1,2 @@
+<h2>Contact</h2>
+<p>{{@model.id}}</p>

--- a/lib/new-about/app/routes/contact.js
+++ b/lib/new-about/app/routes/contact.js
@@ -1,0 +1,1 @@
+export { default } from 'about/routes/contact';

--- a/lib/new-about/app/templates/contact.js
+++ b/lib/new-about/app/templates/contact.js
@@ -1,0 +1,1 @@
+export { default } from 'about/templates/contact';

--- a/lib/new-about/config/environment.js
+++ b/lib/new-about/config/environment.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'new-about',
+    environment
+  };
+
+  return ENV;
+};

--- a/lib/new-about/index.js
+++ b/lib/new-about/index.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+'use strict';
+
+const EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'new-about',
+
+  lazyLoading: Object.freeze({
+    enabled: true
+  }),
+
+  isDevelopingAddon() {
+    return true;
+  }
+});

--- a/lib/new-about/package.json
+++ b/lib/new-about/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "new-about",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  }
+}

--- a/lib/new-super-blog/addon/engine.js
+++ b/lib/new-super-blog/addon/engine.js
@@ -1,0 +1,15 @@
+import Engine from 'ember-engines/engine';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from './resolver';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/lib/new-super-blog/addon/resolver.js
+++ b/lib/new-super-blog/addon/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/lib/new-super-blog/addon/routes.js
+++ b/lib/new-super-blog/addon/routes.js
@@ -1,0 +1,6 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function () {
+  // Define your engine's route map here
+  this.route('post', { path: 'post/:id' });
+});

--- a/lib/new-super-blog/addon/routes/post.js
+++ b/lib/new-super-blog/addon/routes/post.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class PostRoute extends Route {
+  model({ id }) {
+    return { id };
+  }
+}

--- a/lib/new-super-blog/addon/templates/application.hbs
+++ b/lib/new-super-blog/addon/templates/application.hbs
@@ -1,0 +1,3 @@
+<h1>NEW Super Blog Engine (non-lazy)</h1>
+
+{{outlet}}

--- a/lib/new-super-blog/addon/templates/post.hbs
+++ b/lib/new-super-blog/addon/templates/post.hbs
@@ -1,0 +1,1 @@
+<h2>Post {{@model.id}}</h2>

--- a/lib/new-super-blog/app/routes/post.js
+++ b/lib/new-super-blog/app/routes/post.js
@@ -1,0 +1,1 @@
+export { default } from 'super-blog/routes/post';

--- a/lib/new-super-blog/app/templates/post.js
+++ b/lib/new-super-blog/app/templates/post.js
@@ -1,0 +1,1 @@
+export { default } from 'super-blog/templates/post';

--- a/lib/new-super-blog/config/environment.js
+++ b/lib/new-super-blog/config/environment.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'new-super-blog',
+    environment
+  };
+
+  return ENV;
+};

--- a/lib/new-super-blog/index.js
+++ b/lib/new-super-blog/index.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+'use strict';
+
+const EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'new-super-blog',
+
+  lazyLoading: Object.freeze({
+    enabled: false
+  }),
+
+  isDevelopingAddon() {
+    return true;
+  }
+});

--- a/lib/new-super-blog/package.json
+++ b/lib/new-super-blog/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "new-super-blog",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
   "ember-addon": {
     "paths": [
       "lib/about",
-      "lib/super-blog"
+      "lib/new-about",
+      "lib/super-blog",
+      "lib/new-super-blog"
     ]
   }
 }


### PR DESCRIPTION
Check in new-super-blog and new-about and enable the flags in base page,
mountFlagedEngine helper in router.js will be able to mount the expected
engine.

TODO: initial visit to async routes (lazy engine or embroider split
routes) are currently broken, will iterate on the issue.